### PR TITLE
Create rulegroup mapping request

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,7 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: da78ab0128c643f7b3aa684dcc1f0b59
-    digest: b1-MlGDrwTOkqPh-_33iyKOVd2xcAHBYsme_NBq8DZrTF8=
-    create_time: 2021-09-27T15:06:02.540976Z
+    commit: 5abafbf55b5c4c07ad5fb06d2599560f

--- a/com/coralogix/rules/v1/rule_groups_service.proto
+++ b/com/coralogix/rules/v1/rule_groups_service.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package com.coralogix.rules.v1;
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 import "com/coralogix/rules/v1/rule.proto";
 import "com/coralogix/rules/v1/rule_group.proto";
@@ -42,6 +43,14 @@ service RuleGroupsService {
     option (audit_log_description).description = "delete rule group";
     option (google.api.http) = {
       delete: "/api/v1/rulegroups/{group_id}"
+    };
+  }
+
+  rpc GetRuleGroupModelMapping(GetRuleGroupModelMappingRequest) returns (GetRuleGroupModelMappingResponse){
+    option (audit_log_description).description = "get rule mapping";
+    option (google.api.http) = {
+      post: "/api/v1/rulegroup-mapping/"
+      body: "*"
     };
   }
 }
@@ -110,3 +119,44 @@ message DeleteRuleGroupRequest {
 }
 
 message DeleteRuleGroupResponse {}
+
+message GetRuleGroupModelMappingRequest {
+  google.protobuf.StringValue name = 1;
+  google.protobuf.StringValue description = 2;
+  google.protobuf.BoolValue enabled = 3;
+  google.protobuf.BoolValue hidden = 4;
+  google.protobuf.StringValue creator = 5;
+
+  repeated RuleMatcher rule_matchers = 6;
+
+  message CreateRuleSubgroup {
+    message CreateRule {
+      google.protobuf.StringValue name = 1;
+
+      reserved "rule";
+      reserved 2;
+
+      google.protobuf.StringValue description = 3;
+      google.protobuf.StringValue source_field = 4;
+
+      RuleParameters parameters = 5;
+
+      google.protobuf.BoolValue enabled = 6;
+
+      google.protobuf.UInt32Value order = 7;
+    }
+
+    repeated CreateRule rules = 1;
+
+    google.protobuf.BoolValue enabled = 2;
+    google.protobuf.UInt32Value order = 3;
+  }
+
+  repeated CreateRuleSubgroup rule_subgroups = 7;
+
+  google.protobuf.UInt32Value order = 8;
+}
+
+message GetRuleGroupModelMappingResponse {
+  google.protobuf.Struct rule_definition = 1;
+}


### PR DESCRIPTION
As of now the rules screen doesn't work with grpc messages which causes problem when trying to display the rulegroup from the extensions perspective. As a quick solution we provide mapping between the grpc message and the rulegroup model on the backend because it's already been implemented there.

[sc-12565]

Related PR: https://github.com/coralogix/eng-svc-rules-grpc-api/pull/87