### PR TITLE
add optional team id to create rule group request

### DIFF
--- a/com/coralogix/rules/v1/rule_group.proto
+++ b/com/coralogix/rules/v1/rule_group.proto
@@ -21,3 +21,7 @@ message RuleGroup {
 
   google.protobuf.UInt32Value order = 11;
 }
+
+message TeamId {
+  uint32 id = 1;
+}

--- a/com/coralogix/rules/v1/rule_groups_service.proto
+++ b/com/coralogix/rules/v1/rule_groups_service.proto
@@ -98,7 +98,7 @@ message CreateRuleGroupRequest {
   repeated CreateRuleSubgroup rule_subgroups = 7;
 
   google.protobuf.UInt32Value order = 8;
-  optional TeamId team_id = 9;
+  TeamId team_id = 9;
 }
 
 message CreateRuleGroupResponse {

--- a/com/coralogix/rules/v1/rule_groups_service.proto
+++ b/com/coralogix/rules/v1/rule_groups_service.proto
@@ -98,6 +98,7 @@ message CreateRuleGroupRequest {
   repeated CreateRuleSubgroup rule_subgroups = 7;
 
   google.protobuf.UInt32Value order = 8;
+  optional TeamId team_id = 9;
 }
 
 message CreateRuleGroupResponse {


### PR DESCRIPTION
allows rule to be created  for a team (specifically in creating a new team) when signed into another team, when implemented, will check if team id exists as a param, and if not, will take as it does now from auth context